### PR TITLE
osg-test cert creation should have an option to mimic CILogon-style certs

### DIFF
--- a/bin/osg-ca-generator
+++ b/bin/osg-ca-generator
@@ -13,13 +13,23 @@ def main():
                  help='The number of days before generated CAs or certificates expire')
     p.add_option('-f', '--force', action='store_true', default=False, dest='force',
                  help='Overwrite any existing CAs or certificates')
+    p.add_option('--cilogon', action='store_true', default=False, dest='cilogon',
+                 help='Create CILogon-like CA and hostcert instead of DigiCert')
     opts, _ = p.parse_args()
 
-    test_ca = CA('/DC=org/DC=Open Science Grid/O=OSG Test/CN=OSG Test CA', opts.days, opts.force)
+    # Create the CA
+    if opts.cilogon:
+        subject_prefix = '/DC=org/DC=opensciencegrid/C=US/'
+    else:
+        subject_prefix = '/DC=org/DC=Open Science Grid/'
+    test_ca = CA(subject_prefix + 'O=OSG Software/CN=OSG Test CA', opts.days, opts.force)
+
     if test_ca.created:
         print 'Created CA at %s...\n' % test_ca.path
     else:
         print 'Loaded CA at %s...\n' % test_ca.path
+
+    # Create hostcert
     host_path = '/etc/grid-security/hostcert.pem'
     if not os.path.exists(host_path) or opts.force:
         print 'Writing hostcert to %s...\n' % host_path

--- a/bin/osg-ca-generator
+++ b/bin/osg-ca-generator
@@ -20,9 +20,11 @@ def main():
     # Create the CA
     if opts.cilogon:
         subject_prefix = '/DC=org/DC=opensciencegrid/C=US/'
+        mimic = 'cilogon'
     else:
         subject_prefix = '/DC=org/DC=Open Science Grid/'
-    test_ca = CA(subject_prefix + 'O=OSG Software/CN=OSG Test CA', opts.days, opts.force)
+        mimic = 'digicert'
+    test_ca = CA(subject_prefix + 'O=OSG Software/CN=OSG Test CA', opts.days, opts.force, mimic)
 
     if test_ca.created:
         print 'Created CA at %s...\n' % test_ca.path

--- a/lib/cagen.py
+++ b/lib/cagen.py
@@ -21,14 +21,16 @@ class CA(object):
     _EXT_CONFIG_PATH = '/etc/pki/tls/osg-test-extensions.conf'
     _SERIAL_NUM = 'A1B2C3D4E5F6'
 
-    def __init__(self, subject, days=10, force=False):
+    def __init__(self, subject, days=10, force=False, mimic='digicert'):
         """
         Create a CA (and crl) with the given subject.
 
         days - specifies the number of days before the certificate expires
         force - will overwrite any existing certs and keys if set to True
+        mimic - type of CA/certs to mimic: 'cilogon' or 'digicert' (default)
         """
         self.subject = subject
+        self.mimic = mimic
         self.created = False
         try:
             basename = re.search(r'.*\/CN=([^\/]*)', subject).group(1).replace(' ', '-')
@@ -160,27 +162,37 @@ class CA(object):
 
     def _write_openssl_config(self):
         """Place the necessary openssl config required to mimic DigiCert"""
+        if self.mimic == 'cilogon':
+            ext_key_usage = 'critical, cRLSign, keyCertSign'
+            cert_policies = '1.3.6.1.4.1.34998.1.6'
+            key_id = ''
+            pathlen = ''
+        else:
+            ext_key_usage = 'critical, digitalSignature, cRLSign, keyCertSign'
+            cert_policies = '1.2.840.113612.5.2.2.1, 2.16.840.1.114412.31.1.1.1, 1.2.840.113612.5.2.3.3.2'
+            key_id = "authorityKeyIdentifier=keyid,issuer\nsubjectKeyIdentifier=hash\n"
+            pathlen = ', pathlen:0'
+
         openssl_dir = '/etc/pki/CA/' # TODO: This may need to be unique for each CA
-        ext_contents = """authorityKeyIdentifier=keyid,issuer
-    subjectKeyIdentifier=hash
-    subjectAltName=DNS:%s
-    keyUsage=critical,digitalSignature,keyEncipherment,dataEncipherment
-    extendedKeyUsage=serverAuth,clientAuth
-    certificatePolicies=1.2.840.113612.5.2.2.1,2.16.840.1.114412.31.1.1.1,1.2.840.113612.5.2.3.3.2
-    basicConstraints=critical,CA:false
-""" % _get_hostname()
+        ext_contents = """%ssubjectAltName=DNS:%s
+keyUsage=critical,digitalSignature,keyEncipherment,dataEncipherment
+extendedKeyUsage=serverAuth,clientAuth
+certificatePolicies=%s
+basicConstraints=critical,CA:false
+""" % (key_id, _get_hostname(), cert_policies)
 
         openssl_config = open('/etc/pki/tls/openssl.cnf', 'r')
         config_contents = openssl_config.read()
         openssl_config.close()
         replace_text = [("# crl_extensions	= crl_ext", "crl_extensions	= crl_ext"),
-                        ("basicConstraints = CA:true", "basicConstraints = critical, CA:true"),
+                        ("basicConstraints = CA:true", "basicConstraints = critical, CA:true%s" % pathlen),
                         ("# keyUsage = cRLSign, keyCertSign",
-                         "keyUsage = critical, digitalSignature, cRLSign, keyCertSign"),
+                         "keyUsage = %s" % ext_key_usage),
                         ("dir		= ../../CA		# Where everything is kept",
                          "dir		= %s		# Where everything is kept" % openssl_dir)]
         for (old, new) in replace_text:
             config_contents = config_contents.replace(old, new)
+
         _write_file(self._CONFIG_PATH, config_contents)
         _write_file(self._EXT_CONFIG_PATH, ext_contents)
         _write_file(openssl_dir + "index.txt", "")

--- a/lib/cagen.py
+++ b/lib/cagen.py
@@ -219,17 +219,17 @@ class CA(object):
     # @(#)xyxyxyxy.namespaces
     # CA alias    : OSG-Test-CA
     #    subord_of: 
-    #    subjectDN: /DC=org/DC=Open Science Grid/O=OSG Test/CN=OSG Test CA
-    #    hash     : xyxyxyxy
+    #    subjectDN: %s
+    #    hash     : %s
     #
-    TO Issuer "/DC=org/DC=Open Science Grid/O=OSG Test/CN=OSG Test CA" \
-      PERMIT Subject "/DC=org/DC=Open Science Grid/.*"
-    """.replace('xyxyxyxy', hashes[0])
+    TO Issuer "%s" \
+      PERMIT Subject "%s/.*"
+    """ % (self.subject, hashes[0], self.subject, self._subject_base)
         signing_content = """# OSG Test CA Signing Policy
     access_id_CA		X509	'%s'
     pos_rights		globus	CA:sign
-    cond_subjects		globus	'"/DC=org/DC=Open Science Grid/*"'
-    """ % self.subject
+    cond_subjects		globus	'"%s/*"'
+    """ % (self.subject, self._subject_base)
 
         _write_file(os.path.join(self._CERTS_DIR, ca_name + '.namespaces'),
                     namespace_content)


### PR DESCRIPTION
[SOFTWARE-2142](https://jira.opensciencegrid.org/browse/SOFTWARE-2142)

Test results for a run using osg-ca-generator from the CILogon branch but with osg-test out of trunk (i.e. Using osg-ca-generator with added option but still generating DigiCert-style certs): http://vdt.cs.wisc.edu/tests/20160527-1635/results.html. Results look good other than unrelated RHEL subscription management errors and some other transient-looking errors.
