### PR TITLE
Don't overwrite private key if already exists, use OSG-FDQN env var for hostname (if exists) instead of socket hostname in _get_hostname

### DIFF
--- a/lib/cagen.py
+++ b/lib/cagen.py
@@ -360,8 +360,10 @@ def _get_hostname():
     Returns the hostname of the current system, returns None if it can't
     get the hostname. Stolen from osg-test
     """
-    if "OSG-FDQN" in os.environ:
-        return os.getenv("OSG-FDQN")
+    try:
+        return os.getenv('OSG_FQDN')
+    except KeyError:
+        pass
     try:
         return socket.gethostbyaddr(socket.gethostname())[0]
     except socket.error:

--- a/lib/cagen.py
+++ b/lib/cagen.py
@@ -80,7 +80,7 @@ class CA(object):
         self._write_openssl_config()
 
         # Generate the CA
-        if not os.path.exists(self.keypath):
+        if not os.path.exists(self.keypath) and not force:
             _write_rsa_key(self.keypath)
         _, ca_contents, _ = _run_command(('openssl', 'req', '-sha256', '-new', '-x509', '-key', self.keypath,
                                           '-subj', subject, '-config', self._CONFIG_PATH, '-days', str(days)),
@@ -360,8 +360,8 @@ def _get_hostname():
     Returns the hostname of the current system, returns None if it can't
     get the hostname. Stolen from osg-test
     """
-    if "PRP-Node-Name" in os.environ:
-        return os.getenv("PRP-Node-Name")
+    if "OSG-FDQN" in os.environ:
+        return os.getenv("OSG-FDQN")
     try:
         return socket.gethostbyaddr(socket.gethostname())[0]
     except socket.error:

--- a/lib/cagen.py
+++ b/lib/cagen.py
@@ -80,7 +80,8 @@ class CA(object):
         self._write_openssl_config()
 
         # Generate the CA
-        _write_rsa_key(self.keypath)
+        if not os.path.exists(self.keypath):
+            _write_rsa_key(self.keypath)
         _, ca_contents, _ = _run_command(('openssl', 'req', '-sha256', '-new', '-x509', '-key', self.keypath,
                                           '-subj', subject, '-config', self._CONFIG_PATH, '-days', str(days)),
                                          'generate CA')
@@ -359,6 +360,8 @@ def _get_hostname():
     Returns the hostname of the current system, returns None if it can't
     get the hostname. Stolen from osg-test
     """
+    if "PRP-Node-Name" in os.environ:
+        return os.getenv("PRP-Node-Name")
     try:
         return socket.gethostbyaddr(socket.gethostname())[0]
     except socket.error:


### PR DESCRIPTION
- Don't call _write_rsa_key if it exists at self.keypath

- Use 'OSG-FDQN' environment variable as hostname if it exists in _get_hostname()