### PR TITLE
Fix OSG_FQDN query in _get_hostname()

### DIFF
--- a/lib/cagen.py
+++ b/lib/cagen.py
@@ -361,11 +361,7 @@ def _get_hostname():
     get the hostname. Stolen from osg-test
     """
     try:
-        return os.getenv('OSG_FQDN')
-    except KeyError:
-        pass
-    try:
-        return socket.gethostbyaddr(socket.gethostname())[0]
+        return os.getenv("OSG_FQDN") or socket.gethostbyaddr(socket.gethostname())[0]
     except socket.error:
         raise RuntimeError("Failed to retrieve this host's FQDN")
 


### PR DESCRIPTION
os.getenv() returns None instead of raising an error if the variable is undefined.