### PR TITLE
Add necessary key extensions for EL8 (SOFTWARE-4883)

### DIFF
--- a/lib/cagen.py
+++ b/lib/cagen.py
@@ -237,6 +237,8 @@ keyUsage=critical,digitalSignature,keyEncipherment,dataEncipherment
 extendedKeyUsage=serverAuth,clientAuth
 certificatePolicies=%s
 basicConstraints=critical,CA:false
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid:always,issuer
 """ % (key_id, _get_hostname(), cert_policies)
 
         openssl_config = open('/etc/pki/tls/openssl.cnf', 'rb')


### PR DESCRIPTION
Without them, we get the following when trying to generate VOMS
proxies with `voms-proxy-direct`:

```
unable to get issuer keyid
Function: v2i_AUTHORITY_KEYID
error in extensionname=authorityKeyIdentifier, value=keyid:always
```

Tests don't look any worse for wear compared to the nightlies: https://osg-sw-submit.chtc.wisc.edu/tests/20211108-1148/packages.html
